### PR TITLE
Fixed build on Raspberry Stretch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
   set (CMAKE_C_FLAGS "--std=c99 -g ${CMAKE_C_FLAGS}")
 endif()
 
-include_directories("/usr/include/azureiot"
-                    "/usr/include/azureiot/inc/")
+include_directories("/usr/local/include/azureiot"
+                    "/usr/local/include/azureiot/inc/")
 
 set(SOURCE main.c bme280.c wiring.c telemetry.c config.h bme280.h wiring.h telemetry.h)
 add_executable(app ${SOURCE})

--- a/main.c
+++ b/main.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <azure_c_shared_utility/xlogging.h>
 #include <azure_c_shared_utility/platform.h>
 #include <azure_c_shared_utility/threadapi.h>
 #include <azure_c_shared_utility/crt_abstractions.h>

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
+sh -c '
+#On Raspbian Stretch we need to install old libssl (1.02 to be exact)
+sudo apt-get update
+sudo apt-get purge -y libssl-dev
+sudo apt-get install -y libssl1.0-dev git cmake build-essential curl libcurl4-openssl-dev uuid-dev
+
+#On Raspbian Stretch precompiled sdk from ppa is no good. Lets compile it manually
+cd ~
+mkdir Source
+cd Source
+git clone --recursive https://github.com/azure/azure-iot-sdk-c.git
+
+cd azure-iot-sdk-c/build_all/linux
+./build.sh --no-make
+
+cd ../../cmake/iotsdk_linux
+make
+
+sudo make install
+'
+
 vercomp() {
     if [[ $1 == $2 ]]
     then
@@ -49,13 +70,6 @@ then
 else
     echo "cmake version check pass (current:$CMAKE_VER,require:$CMAKE_LEAST)"
 fi
-
-
-grep -q -F 'deb http://ppa.launchpad.net/aziotsdklinux/ppa-azureiot/ubuntu vivid main' /etc/apt/sources.list || sudo sh -c "echo 'deb http://ppa.launchpad.net/aziotsdklinux/ppa-azureiot/ubuntu vivid main' >> /etc/apt/sources.list"
-grep -q -F 'deb-src http://ppa.launchpad.net/aziotsdklinux/ppa-azureiot/ubuntu vivid main' /etc/apt/sources.list || sudo sh -c "echo 'deb-src http://ppa.launchpad.net/aziotsdklinux/ppa-azureiot/ubuntu vivid main' >> /etc/apt/sources.list"
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FDA6A393E4C2257F
-sudo apt-get update
-sudo apt-get install -y azure-iot-sdk-c-dev cmake libcurl4-openssl-dev
 
 git clone git://git.drogon.net/wiringPi
 cd ./wiringPi


### PR DESCRIPTION
Moved away from precompiled Azure C SDK libraries.


The problem is that libcurl requires OpenSSL shared objects version 1.0.2. This version of OpenSSL is installed by default when you install Stretch. However, when you prepare to compile the Azure IoT SDK for C (also for Python) you are required to install the package libssl-dev. This will install version 1.1. Which leads to 
```
/usr/bin/ld: warning: libssl.so.1.0.2, needed by /usr/lib/gcc/arm-linux-gnueabihf/6/../../../arm-linux-gnueabihf/libcurl.so, may conflict with libssl.so.1.1
/usr/bin/ld: /usr/lib/gcc/arm-linux-gnueabihf/6/../../../libaziotsharedutil.a(tlsio_openssl.c.o): undefined reference to symbol 'SSL_load_error_strings@@OPENSSL_1.0.2d'
//usr/lib/arm-linux-gnueabihf/libssl.so.1.0.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
Also this change fixes the error described in comment from Coyotex1969 (@see comment section in https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-raspberry-pi-kit-c-get-started)