### PR TITLE
Added a script to get parson files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 include_directories("/usr/local/include/azureiot"
                     "/usr/local/include/azureiot/inc/")
 
-set(SOURCE main.c bme280.c wiring.c telemetry.c config.h bme280.h wiring.h telemetry.h)
+set(SOURCE main.c bme280.c wiring.c telemetry.c parson.c config.h bme280.h wiring.h telemetry.h parson.h)
 add_executable(app ${SOURCE})
 target_link_libraries(app wiringPi
                           serializer

--- a/setup.sh
+++ b/setup.sh
@@ -76,6 +76,11 @@ cd ./wiringPi
 ./build
 cd ..
 
+git clone https://github.com/kgabis/parson.git
+cd ./parson
+mv parson.c parson.h ..
+cd ..
+rm -rf parson
 
 if [[ $1 == "--simulated-data" ]]; then
     echo -e "Using simulated data"


### PR DESCRIPTION
Addressing issues due to missing parson.h and parson.c files
MicrosoftDocs/azure-docs#23151
MicrosoftDocs/azure-docs#22810
https://github.com/MicrosoftDocs/azure-docs/issues/24308

Apparently Parson it is not available in the SDK anymore it was hidden in this PR [Hide parson library in .so. Version and install .so files properly](https://github.com/Azure/azure-iot-sdk-c/pull/386/files)  more detail on this issue here Azure/azure-iot-sdk-c#490
https://github.com/Azure-Samples/iot-hub-c-raspberrypi-client-app/issues/27
https://github.com/Azure-Samples/iot-hub-c-raspberrypi-client-app/issues/25

**Note** this only fixes the parson error. Once resolved there is another ongoing issue with  missing xlogging.h see https://github.com/Azure-Samples/iot-hub-c-raspberrypi-client-app/issues/22 