### PR TITLE
Updated WiringPi repo address

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -71,8 +71,8 @@ else
     echo "cmake version check pass (current:$CMAKE_VER,require:$CMAKE_LEAST)"
 fi
 
-git clone git://git.drogon.net/wiringPi
-cd ./wiringPi
+git clone https://github.com/WiringPi/WiringPi.git
+cd ./WiringPi
 ./build
 cd ..
 


### PR DESCRIPTION
The repo git://git.drogon.net/wiringPi no longer exists as project is inactive.
Updated repo link to use an unofficial mirror of the last offical source release instead  https://github.com/WiringPi/WiringPi.