### PR TITLE
fixes MicrosoftDocs/azure-docs#76421

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 sh -c '
-#On Raspbian Stretch we need to install old libssl (1.02 to be exact)
 sudo apt-get update
-sudo apt-get purge -y libssl-dev
-sudo apt-get install -y libssl1.0-dev git cmake build-essential curl libcurl4-openssl-dev uuid-dev
+sudo apt-get install -y libssl-dev git cmake build-essential curl libcurl4-openssl-dev uuid-dev
 
 #On Raspbian Stretch precompiled sdk from ppa is no good. Lets compile it manually
 cd ~
@@ -71,8 +69,8 @@ else
     echo "cmake version check pass (current:$CMAKE_VER,require:$CMAKE_LEAST)"
 fi
 
-git clone git://git.drogon.net/wiringPi
-cd ./wiringPi
+git clone https://github.com/WiringPi/WiringPi
+cd ./WiringPi
 ./build
 cd ..
 


### PR DESCRIPTION
This fixes two issues as mentioned in [Microsoft Docs/Azure-docs#76421](https://github.com/MicrosoftDocs/azure-docs/issues/76421). A summary is as follows...

There are two problems with the `setup.sh` script that are causing customer problems:

1. Using the latest version of **Raspberry Pi OS with desktop** we don't appear to need to install the specific 1.02 version of `libssl-dev` anymore. In fact this fails and causes a cascade of other failures. Which follow...

    - [Install of `libssl1.0-dev`](https://github.com/Azure-Samples/iot-hub-c-raspberrypi-client-app/blob/master/setup.sh#L6) fails then no openssl components are installed. These are necessary to build the IoT C SDK. 
    - CMake is not installed. You have to install manually before building and installing the C IoT SDK.
    - Without the IoT C SDK built and installed you end up with `xlogging.h` missing as mentioned in [Git Hub issue 22](https://github.com/Azure-Samples/iot-hub-c-raspberrypi-client-app/issues/22).

2. The `wiringPi` repo [referenced in the script](https://github.com/Azure-Samples/iot-hub-c-raspberrypi-client-app/blob/master/setup.sh#L74) is no longer available. When this fails we still change to the parent directory of the repo folder [here](https://github.com/Azure-Samples/iot-hub-c-raspberrypi-client-app/blob/master/setup.sh#L77) and end up placing `parson.h` and `parson.c` there instead of the repo folder where they belong. A fix for this can be... 

    ```
    git clone https://github.com/WiringPi/WiringPi
    cd ./WiringPi
    ./build
    cd ..
    ```

    With this change, `parson.h` and `parson.c` should be placed in the correct repo folder by the script. We also get a working version of WiringPi and I have verified this script update against the latest **Raspberry Pi OS with desktop** image released May 7th 2021.