### PR TITLE
Update setup script to align with IoT C SDK build output

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ git clone --recursive https://github.com/azure/azure-iot-sdk-c.git
 cd azure-iot-sdk-c/build_all/linux
 ./build.sh --no-make
 
-cd ../../cmake/iotsdk_linux
+cd ../../cmake
 make
 
 sudo make install


### PR DESCRIPTION
Running `sudo ./setup.sh` as described in the [tutorial](https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-raspberry-pi-kit-c-get-started#configure-the-sample-application) results in an error below.

```
[ 16%] Building C object CMakeFiles/app.dir/main.c.o
**REDACTED**/main.c:9:10: fatal error: azure_c_shared_utility/xlogging.h: No such file or directory
    9 | #include <azure_c_shared_utility/xlogging.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/app.dir/build.make:76: CMakeFiles/app.dir/main.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/app.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

This occurs as `setup.sh` assumes the directory `{build_root}/cmake/iotsdk_linux` to be the build output of IoT C SDK.
It was so in the past ([example](https://github.com/Azure/azure-iot-sdk-c/blob/LTS_07_2019_Ref01/build_all/linux/build.sh#L20)), but the current output is `{build_root}/cmake` instead ([example](https://github.com/Azure/azure-iot-sdk-c/blob/main/build_all/linux/build.sh#L20)). Due to this mismatch installation of IoT C SDK ends midway, leaving no actual library for the application code to reference.

```
+ build_folder=/home/***/Source/azure-iot-sdk-c/cmake
...
~/Source/azure-iot-sdk-c/build_all/linux
sh: 14: cd: can't cd to ../../cmake/iotsdk_linux
make: *** No targets specified and no makefile found.  Stop.
make: *** No rule to make target 'install'.  Stop.
...
```

With the proposed change, `setup.sh` would reference the correct directory, thereby installing the SDK and succeeding in building the app.
